### PR TITLE
applicationId was renamed to projectId

### DIFF
--- a/projects/ama-sdk/src/lib/api-implementations/acm-api/model-api.ts
+++ b/projects/ama-sdk/src/lib/api-implementations/acm-api/model-api.ts
@@ -153,7 +153,7 @@ export class ModelApi<T extends Model, S> implements ModelApiInterface<T, S> {
         return {
             description: '',
             version: '0.0.1',
-            applicationId: containerId,
+            applicationId: entity.projectId,
             // Patch: BE does not return empty or not yet defined properties at all, like extensions
             ...(this.modelVariation.patchModel(entity) as object)
         } as T;

--- a/projects/ama-sdk/src/lib/api/types.ts
+++ b/projects/ama-sdk/src/lib/api/types.ts
@@ -54,7 +54,8 @@ export interface Model extends MinimalModelSummary {
     id: string;
     description: string;
     version: string;
-    applicationId: string;
+    applicationId?: string; // To remove, since BE finally returns it
+    projectId: string;
     type: string;
     creationDate: Date;
     createdBy: string;


### PR DESCRIPTION
Projects endpoint fix: the response contains projectId instead of applicationId.