### PR TITLE
[APM-727] Fix wrong package.json sed (version change leaves the file invalid)

### DIFF
--- a/charts/activiti-modeling-app/Makefile
+++ b/charts/activiti-modeling-app/Makefile
@@ -39,7 +39,7 @@ else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
 	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/activiti\/activiti-modeling-app|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
-	sed -i -e "s/\"version\":.*/\"version\": \"$(RELEASE_VERSION)\"/" ../../package.json
+	sed -i -e "s/\"version\":.*/\"version\": \"$(RELEASE_VERSION)\",/" ../../package.json
 else
 	echo "platfrom $(OS) not supported to release from"
 	exit -1

--- a/charts/activiti-modeling-app/Makefile
+++ b/charts/activiti-modeling-app/Makefile
@@ -34,12 +34,12 @@ tag:
 ifeq ($(OS),Darwin)
 	sed -i "" -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
-	sed -i "" -e "s/\"version\":.*/\"version\": \"$(RELEASE_VERSION)\",/" ../../package.json
+	npm run update-package-version -- "$(RELEASE_VERSION)"
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
 	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/activiti\/activiti-modeling-app|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
-	sed -i -e "s/\"version\":.*/\"version\": \"$(RELEASE_VERSION)\",/" ../../package.json
+	npm run update-package-version -- "$(RELEASE_VERSION)"
 else
 	echo "platfrom $(OS) not supported to release from"
 	exit -1

--- a/charts/activiti-modeling-app/Makefile
+++ b/charts/activiti-modeling-app/Makefile
@@ -34,12 +34,12 @@ tag:
 ifeq ($(OS),Darwin)
 	sed -i "" -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
-	sed -i "" -e "s/\"version\":.*/\"version\": \"$(RELEASE_VERSION)\"/" ../../package.json
+	sed -i "" -e "s/\"version\":.*/\"version\": \"$(RELEASE_VERSION)\",/" ../../package.json
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
 	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/activiti\/activiti-modeling-app|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
-	sed -i -e "s/\"version\":.*/\"version\": \"$(RELEASE_VERSION)\"/" ../../package.json	
+	sed -i -e "s/\"version\":.*/\"version\": \"$(RELEASE_VERSION)\"/" ../../package.json
 else
 	echo "platfrom $(OS) not supported to release from"
 	exit -1

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Alfresco Software, Ltd.",
   "scripts": {
     "ng": "ng",
+    "update-package-version": "./scripts/update-package-version.sh",
     "postinstall": "node jest/transpile-es2015-modules-for-jest.js",
     "01": "echo --------------------------------------- Community servers ------------------------------------------",
     "prestart": "npm run validate-config && rimraf dist && npm run compile-less && npm run package:sdk",

--- a/scripts/update-package-version.sh
+++ b/scripts/update-package-version.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+PACKAGE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+VERSION=$1
+
+eval packages=(
+    "$PACKAGE_DIR"
+    "$PACKAGE_DIR/projects/ama-sdk"
+    "$PACKAGE_DIR/projects/ama-testing"
+)
+packagesLength=${#packages[@]}
+
+for (( j=0; j<${packagesLength}; j++ ));
+    do
+        PACKAGE_PATH="${packages[$j]}"
+        echo "====== UPDATE PACKAGE VERSION of ${packages[$j]} to ${VERSION} ======"
+        cd $PACKAGE_PATH;
+        npm version --no-git-tag-version --force $VERSION
+    done


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [x] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
`make tag` leaves the package json in an invalid state (missing `,` from  the end of the version's line)


**What is the new behaviour?**
Fixed


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
