### PR TITLE
[APM-1109] Move mapping editor to SDK to make it reusable

### DIFF
--- a/projects/ama-sdk/i18n/en.json
+++ b/projects/ama-sdk/i18n/en.json
@@ -18,6 +18,13 @@
                 "COLUMN_VALUE": "Value",
                 "NO_PROPERTIES": "You don't have any property selected"
             }
+        },
+        "VARIABLE_MAPPING": {
+            "PARAMETER": "Parameter",
+            "VALUE": "Value",
+            "PROCESS_VARIABLE": "Process variable",
+            "SWITCH_VAR_VAL": "Switch variable/value",
+            "NO_PROCESS_PROPERTIES": "No process properties"
         }
     }
 }

--- a/projects/ama-sdk/i18n/en.json
+++ b/projects/ama-sdk/i18n/en.json
@@ -24,7 +24,8 @@
             "VALUE": "Value",
             "PROCESS_VARIABLE": "Process variable",
             "SWITCH_VAR_VAL": "Switch variable/value",
-            "NO_PROCESS_PROPERTIES": "No process properties"
+            "NO_PROCESS_PROPERTIES": "No process properties",
+            "CLEAR_ASSIGNMENT": "Clear assignment"
         }
     }
 }

--- a/projects/ama-sdk/src/lib/components/input-mapping-table/input-mapping-table.component.html
+++ b/projects/ama-sdk/src/lib/components/input-mapping-table/input-mapping-table.component.html
@@ -19,14 +19,14 @@
             {{ 'SDK.VARIABLE_MAPPING.VALUE' | translate }}
         </mat-header-cell>
         <mat-cell *matCellDef="let parameter">
-            <ng-container *ngIf="mappingTypes[parameter.name] === VALUE_TYPE">
-               <input matInput
+            <div *ngIf="mappingTypes[parameter.name] === VALUE_TYPE">
+                <input matInput
                     class="amasdk-input-mapping-table__mapped-value"
                     [(ngModel)]="values[parameter.name]"
                     (change)="setParamWithValue(values[parameter.name], parameter)"
                     [attr.data-automation-id]="'value-input-' + parameter.id"
                 />
-            </ng-container>
+            </div>
             <ng-container *ngIf="mappingTypes[parameter.name] === VARIABLE_TYPE">
                 <mat-select
                     *ngIf="isThereOptionForParam(parameter); else noProcessPropertiesTmpl"

--- a/projects/ama-sdk/src/lib/components/input-mapping-table/input-mapping-table.component.html
+++ b/projects/ama-sdk/src/lib/components/input-mapping-table/input-mapping-table.component.html
@@ -1,0 +1,60 @@
+<mat-table [dataSource]="dataSource">
+    <ng-container matColumnDef="name">
+        <mat-header-cell data-automation-id="table-header-cell-name" *matHeaderCellDef>{{ 'SDK.VARIABLE_MAPPING.PARAMETER' | translate }}</mat-header-cell>
+        <mat-cell
+            *matCellDef="let parameter"
+            matTooltip="{{ parameter.description + ' (type: ' + parameter.type + ')' }}"
+            matTooltipPosition="before"
+            matTooltipShowDelay="1000"
+            [attr.data-automation-id]="'param-id-' + parameter.id">
+            <span>
+                {{ parameter.name }}
+                <span class="required-parameter" *ngIf="parameter.required">*</span>
+            </span>
+        </mat-cell>
+    </ng-container>
+    <ng-container matColumnDef="process-variable">
+        <mat-header-cell data-automation-id="table-header-cell-process-variables" *matHeaderCellDef>
+            {{ 'PROCESS_EDITOR.ELEMENT_PROPERTIES.PROCESS_VARIABLE' | translate }} /
+            {{ 'SDK.VARIABLE_MAPPING.VALUE' | translate }}
+        </mat-header-cell>
+        <mat-cell *matCellDef="let parameter">
+            <ng-container *ngIf="mappingTypes[parameter.name] === VALUE_TYPE">
+               <input matInput
+                    class="amasdk-input-mapping-table__mapped-value"
+                    [(ngModel)]="values[parameter.name]"
+                    (change)="setParamWithValue(values[parameter.name], parameter)"
+                    [attr.data-automation-id]="'value-input-' + parameter.id"
+                />
+            </ng-container>
+            <ng-container *ngIf="mappingTypes[parameter.name] === VARIABLE_TYPE">
+                <mat-select
+                    *ngIf="isThereOptionForParam(parameter); else noProcessPropertiesTmpl"
+                    placeholder="{{ 'SDK.VARIABLE_MAPPING.PROCESS_VARIABLE' | translate }}"
+                    (selectionChange)="selectVariable($event.value, parameter)"
+                    [compareWith]="compareWith"
+                    [(ngModel)]="paramName2VariableName[parameter.name]"
+                    [value] = "paramName2VariableName[parameter.name]"
+                    [attr.data-automation-id]="'variable-selector-' + parameter.id">
+                    <mat-option *ngFor="let property of optionsForParams[parameter.name]" [value]="property">
+                        {{ property.name }}
+                    </mat-option>
+                </mat-select>
+            </ng-container>
+            <mat-icon
+                [attr.data-automation-id]="'toggle-icon-' + parameter.id"
+                matTooltip="{{ 'SDK.VARIABLE_MAPPING.SWITCH_VAR_VAL' | translate }}"
+                matTooltipPosition="before"
+                matTooltipShowDelay="1000"
+                (click)="toggle(parameter.name)"
+                class="amasdk-input-mapping-table__mapping-icon">{{ mappingTypes[parameter.name] === VALUE_TYPE ? 'layers_clear' : 'layers'}}
+            </mat-icon>
+        </mat-cell>
+    </ng-container>
+    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+    <mat-row *matRowDef="let row; columns: displayedColumns; let i = index;"></mat-row>
+</mat-table>
+
+<ng-template #noProcessPropertiesTmpl>
+    <span class="no-process-properties-msg">{{ 'SDK.VARIABLE_MAPPING.NO_PROCESS_PROPERTIES' | translate }}</span>
+</ng-template>

--- a/projects/ama-sdk/src/lib/components/input-mapping-table/input-mapping-table.component.html
+++ b/projects/ama-sdk/src/lib/components/input-mapping-table/input-mapping-table.component.html
@@ -15,7 +15,7 @@
     </ng-container>
     <ng-container matColumnDef="process-variable">
         <mat-header-cell data-automation-id="table-header-cell-process-variables" *matHeaderCellDef>
-            {{ 'PROCESS_EDITOR.ELEMENT_PROPERTIES.PROCESS_VARIABLE' | translate }} /
+            {{ 'SDK.VARIABLE_MAPPING.PROCESS_VARIABLE' | translate }} /
             {{ 'SDK.VARIABLE_MAPPING.VALUE' | translate }}
         </mat-header-cell>
         <mat-cell *matCellDef="let parameter">

--- a/projects/ama-sdk/src/lib/components/input-mapping-table/input-mapping-table.component.scss
+++ b/projects/ama-sdk/src/lib/components/input-mapping-table/input-mapping-table.component.scss
@@ -1,0 +1,52 @@
+@mixin amasdk-input-mapping-table($theme) {
+    $foreground: map-get($theme, foreground);
+    $error: map-get($theme, warn);
+
+    .amasdk-input-mapping-table {
+        .mat-table {
+            border: 1px solid mat-color($foreground, text, 0.07);
+        }
+
+        .mat-header-cell:first-of-type {
+            padding-left: 0;
+        }
+
+        .mat-header-cell:last-of-type {
+            padding-right: 0;
+        }
+
+        .required-parameter {
+            color: mat-color($error);
+        }
+
+        .mat-cell {
+            margin: 0;
+            padding: 0;
+            display: block;
+            min-height: initial;
+            display: flex;
+            justify-content: space-between;
+        }
+
+        .mat-header-cell {
+            padding-left: 0;
+            padding-right: 0;
+            margin-left: 0;
+        }
+
+        &__mapped-value {
+            border: 1px solid mat-color($foreground, text, 0.07);
+            margin-top: 0;
+        }
+
+        &__mapping-icon.mat-icon {
+            vertical-align: middle;
+            margin-left: 5px;
+            width: 20px;
+            height: 20px;
+            &:hover {
+                cursor: pointer;
+            }
+        }
+    }
+}

--- a/projects/ama-sdk/src/lib/components/input-mapping-table/input-mapping-table.component.spec.ts
+++ b/projects/ama-sdk/src/lib/components/input-mapping-table/input-mapping-table.component.spec.ts
@@ -1,0 +1,226 @@
+ /*!
+ * @license
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MappingType } from '../../api/types';
+import { InputMappingTableComponent, NoneValue } from './input-mapping-table.component';
+import { InputMappingTableModule } from './input-mapping-table.module';
+import { CoreModule } from '@alfresco/adf-core';
+
+describe('InputMappingTableComponent', () => {
+    let fixture: ComponentFixture<InputMappingTableComponent>;
+    let component: InputMappingTableComponent;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                CoreModule.forRoot(),
+                InputMappingTableModule,
+                NoopAnimationsModule,
+                FormsModule
+            ],
+            schemas: [NO_ERRORS_SCHEMA]
+        });
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(InputMappingTableComponent);
+        component = fixture.componentInstance;
+        component.parameters = [{
+            id: 'id1',
+            name: 'name',
+            description: 'desc',
+            required: false,
+            type: 'string'
+        }];
+        component.processProperties = [
+            {
+                id: '1',
+                name: 'var1',
+                type: 'string',
+                required: false,
+                value: ''
+            },
+            {
+                id: '2',
+                name: 'var2',
+                type: 'date',
+                required: false,
+                value: ''
+            }
+        ];
+        component.mapping = {};
+
+        component.ngOnChanges();
+        fixture.detectChanges();
+    });
+
+    afterEach(() => {
+        TestBed.resetTestingModule();
+    });
+
+    it('should render component', () => {
+        expect(component).not.toBeNull();
+    });
+
+    it('should emit the correct data when a property value is set to a variable', () => {
+        spyOn(component.update, 'emit');
+        const select = fixture.debugElement.query(By.css('.mat-select-trigger'));
+        select.nativeElement.click();
+        fixture.detectChanges();
+
+        const options = fixture.debugElement.queryAll(By.css('.mat-option'));
+        options[1].nativeElement.click();
+        fixture.detectChanges();
+
+        const data = { ...component.data, [component.parameters[0].name]: {
+            type: MappingType.variable,
+            value: component.processProperties[0].name
+        }};
+        expect(component.update.emit).toHaveBeenCalledWith(data);
+    });
+
+    it('should emit the correct data when a required property variable is reset to None', () => {
+        spyOn(component.update, 'emit');
+        component.parameters[0].required = true;
+        component.mapping = {
+            'name' : {
+                type: MappingType.variable,
+                value: 'var1'
+            }
+        };
+        component.ngOnChanges();
+        fixture.detectChanges();
+
+        const select = fixture.debugElement.query(By.css('.mat-select-trigger'));
+        select.nativeElement.click();
+        fixture.detectChanges();
+
+        const options = fixture.debugElement.queryAll(By.css('.mat-option'));
+        options[0].nativeElement.click();
+        fixture.detectChanges();
+
+        const data = {
+            'name' : {
+                type: MappingType.variable,
+                value: null
+            }
+        };
+        expect(component.update.emit).toHaveBeenCalledWith(data);
+    });
+
+    it('should emit the correct data when a NON-required property variable is reset to None', () => {
+        spyOn(component.update, 'emit');
+        component.parameters[0].required = false;
+        component.mapping = {
+            'name' : {
+                type: MappingType.variable,
+                value: 'var1'
+            }
+        };
+        component.ngOnChanges();
+        fixture.detectChanges();
+
+        const select = fixture.debugElement.query(By.css('.mat-select-trigger'));
+        select.nativeElement.click();
+        fixture.detectChanges();
+
+        const options = fixture.debugElement.queryAll(By.css('.mat-option'));
+        options[0].nativeElement.click();
+        fixture.detectChanges();
+
+        const data = {};
+        expect(component.update.emit).toHaveBeenCalledWith(data);
+    });
+
+    it('should filter the processProperties', () => {
+        const select = fixture.debugElement.query(By.css('.mat-select-trigger'));
+        select.nativeElement.click();
+        fixture.detectChanges();
+
+        const options = fixture.debugElement.queryAll(By.css('.mat-option'));
+        expect(options.length).toBe(2);
+    });
+
+    it('should display a message if no process property in case of required parameter if there is no matching type', () => {
+        component.parameters[0].type = 'boolean';
+        component.parameters[0].required = true;
+        component.ngOnChanges();
+        fixture.detectChanges();
+
+        const select = fixture.debugElement.query(By.css('.mat-select'));
+        const noPropMsg = fixture.debugElement.query(By.css('.no-process-properties-msg'));
+
+        expect(select).toBeNull();
+        expect(noPropMsg).not.toBeNull();
+    });
+
+    it('should display a selectbox with "None" as first option in case of non-required parameter if there is a matching type', () => {
+        component.parameters[0].type = 'string';
+        component.parameters[0].required = true;
+        component.ngOnChanges();
+        fixture.detectChanges();
+
+        const select = fixture.debugElement.query(By.css('.mat-select'));
+        const noPropMsg = fixture.debugElement.query(By.css('.no-process-properties-msg'));
+
+        expect(select).not.toBeNull();
+        expect(noPropMsg).toBeNull();
+        expect(component.optionsForParams['name'][0]).toEqual({id: NoneValue, name: 'None'});
+    });
+
+    it('should display a selectbox with "None" as first option in case of non-required parameter', () => {
+        component.parameters[0].type = 'string';
+        component.parameters[0].required = false;
+        component.ngOnChanges();
+        fixture.detectChanges();
+
+        expect(component.optionsForParams['name'][0]).toEqual({id: NoneValue, name: 'None'});
+    });
+
+    it('clicking on the icon should toggle it', () => {
+        component.mappingTypes['name'] = MappingType.variable;
+        fixture.detectChanges();
+        const icon = fixture.debugElement.query(By.css('.mapping-icon'));
+        icon.nativeElement.click();
+        fixture.detectChanges();
+
+        expect(component.mappingTypes['name']).toBe(MappingType.value);
+    });
+
+    it('when layers icon is visible process variables select box is visible', () => {
+        component.mappingTypes['name'] = MappingType.variable;
+        fixture.detectChanges();
+        const selectBox = fixture.debugElement.query(By.css('.mat-select'));
+
+        expect(selectBox).not.toBeNull();
+    });
+
+    it('when layers_clear icon is visible process value input box is visible', () => {
+        component.mappingTypes['name'] = MappingType.value;
+        fixture.detectChanges();
+        const inputBox = fixture.debugElement.query(By.css('.mapped-value'));
+
+        expect(inputBox).not.toBeNull();
+    });
+
+});

--- a/projects/ama-sdk/src/lib/components/input-mapping-table/input-mapping-table.component.spec.ts
+++ b/projects/ama-sdk/src/lib/components/input-mapping-table/input-mapping-table.component.spec.ts
@@ -200,7 +200,7 @@ describe('InputMappingTableComponent', () => {
     it('clicking on the icon should toggle it', () => {
         component.mappingTypes['name'] = MappingType.variable;
         fixture.detectChanges();
-        const icon = fixture.debugElement.query(By.css('.mapping-icon'));
+        const icon = fixture.debugElement.query(By.css('.amasdk-input-mapping-table__mapping-icon'));
         icon.nativeElement.click();
         fixture.detectChanges();
 
@@ -218,7 +218,7 @@ describe('InputMappingTableComponent', () => {
     it('when layers_clear icon is visible process value input box is visible', () => {
         component.mappingTypes['name'] = MappingType.value;
         fixture.detectChanges();
-        const inputBox = fixture.debugElement.query(By.css('.mapped-value'));
+        const inputBox = fixture.debugElement.query(By.css('.amasdk-input-mapping-table__mapped-value'));
 
         expect(inputBox).not.toBeNull();
     });

--- a/projects/ama-sdk/src/lib/components/input-mapping-table/input-mapping-table.component.ts
+++ b/projects/ama-sdk/src/lib/components/input-mapping-table/input-mapping-table.component.ts
@@ -1,0 +1,151 @@
+ /*!
+ * @license
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
+import { MatTableDataSource } from '@angular/material';
+import { ConnectorParameter, EntityProperty, MappingType, ServiceInputParameterMapping, ServiceParameterMappings } from '../../api/types';
+
+export interface ParameterSelectOption {
+    id: string | Symbol;
+    name: string;
+}
+export interface ParametersSelectOptions {
+    [paramName: string]: ParameterSelectOption[];
+}
+export const NoneValue = Symbol('None value');
+
+@Component({
+    selector: 'amasdk-input-mapping-table',
+    templateUrl: 'input-mapping-table.component.html',
+    host: { class: 'amasdk-input-mapping-table' }
+})
+export class InputMappingTableComponent implements OnChanges {
+    @Input()
+    parameters: ConnectorParameter[];
+
+    @Input()
+    processProperties: EntityProperty[];
+
+    @Input()
+    mapping: ServiceInputParameterMapping;
+
+    @Output()
+    update = new EventEmitter<ServiceParameterMappings>();
+
+    data: ServiceInputParameterMapping = {};
+
+    VALUE_TYPE = MappingType.value;
+    VARIABLE_TYPE = MappingType.variable;
+
+    displayedColumns: string[] = ['name', 'process-variable'];
+    dataSource: MatTableDataSource<ConnectorParameter>;
+    dataSelect: any[] = [];
+    optionsForParams: ParametersSelectOptions = {};
+    mappingTypes: { [paramName: string]: MappingType } = {};
+    values: { [paramName: string]: string } = {};
+    paramName2VariableName: { [paramName: string]: string } = {};
+
+    ngOnChanges() {
+        this.initOptionsForParams();
+        this.initMapping();
+        this.dataSource = new MatTableDataSource(this.parameters);
+        this.data = { ...this.mapping };
+    }
+
+    selectVariable(
+        selection: ParameterSelectOption,
+        param: ConnectorParameter
+    ): void {
+        const noneSelected = selection.id === NoneValue;
+
+        if (noneSelected && !param.required) {
+            delete this.data[param.name];
+        } else {
+            this.data[param.name] = {
+                type: MappingType.variable,
+                value: noneSelected ? null : selection.name
+            };
+        }
+        this.update.emit(this.data);
+    }
+
+    setParamWithValue(value: string, param: ConnectorParameter): void {
+        if (!value.length && !param.required) {
+            delete this.data[param.name];
+        } else {
+            this.data[param.name] = {
+                type: MappingType.value,
+                value
+            };
+        }
+        this.update.emit(this.data);
+    }
+
+    initOptionsForParams() {
+        this.parameters.forEach(param => {
+            this.optionsForParams[param.name] = [
+                { id: NoneValue, name: 'None' },
+                ...this.processProperties.filter(
+                    prop => prop.type === param.type
+                )
+            ];
+        });
+    }
+
+    initMapping() {
+        this.parameters.forEach(param => {
+            if (!this.mappingTypes[param.name]) {
+                this.mappingTypes[param.name] = MappingType.variable;
+            }
+
+            if (this.mapping[param.name]) {
+                this.mappingTypes[param.name] = this.mapping[param.name].type;
+                this.values[param.name] =
+                    this.mapping[param.name].type === MappingType.value
+                        ? this.mapping[param.name].value
+                        : '';
+                this.paramName2VariableName[param.name] =
+                    this.mapping[param.name].type === MappingType.variable
+                        ? this.mapping[param.name].value
+                        : '';
+            }
+        });
+    }
+
+    compareWith(option: ParameterSelectOption, selectedVariableName: string) {
+        if (selectedVariableName === null && option.id === NoneValue) {
+            return true;
+        }
+
+        return option.name === selectedVariableName;
+    }
+
+    isThereOptionForParam(parameter: ConnectorParameter) {
+        if (parameter.required) {
+            return this.optionsForParams[parameter.name].length > 1;
+        }
+
+        return this.optionsForParams[parameter.name].length > 0;
+    }
+
+    toggle(paramName: string) {
+        this.mappingTypes[paramName] =
+            this.mappingTypes[paramName] === MappingType.variable
+                ? MappingType.value
+                : MappingType.variable;
+    }
+}

--- a/projects/ama-sdk/src/lib/components/input-mapping-table/input-mapping-table.module.ts
+++ b/projects/ama-sdk/src/lib/components/input-mapping-table/input-mapping-table.module.ts
@@ -1,0 +1,43 @@
+ /*!
+ * @license
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import {
+    MatTableModule,
+    MatIconModule,
+    MatTooltipModule,
+    MatSelectModule,
+    MatInputModule
+} from '@angular/material';
+import { InputMappingTableComponent } from './input-mapping-table.component';
+import { CoreModule } from '@alfresco/adf-core';
+
+@NgModule({
+    imports: [
+        CommonModule,
+        MatTableModule,
+        MatIconModule,
+        MatTooltipModule,
+        MatSelectModule,
+        MatInputModule,
+        CoreModule.forChild()
+    ],
+    declarations: [InputMappingTableComponent],
+    exports: [InputMappingTableComponent]
+})
+export class InputMappingTableModule {}

--- a/projects/ama-sdk/src/lib/components/input-mapping-table/public_api.ts
+++ b/projects/ama-sdk/src/lib/components/input-mapping-table/public_api.ts
@@ -1,0 +1,19 @@
+ /*!
+ * @license
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './input-mapping-table.component';
+export * from './input-mapping-table.module';

--- a/projects/ama-sdk/src/lib/components/output-mapping-table/output-mapping-table.component.html
+++ b/projects/ama-sdk/src/lib/components/output-mapping-table/output-mapping-table.component.html
@@ -1,0 +1,45 @@
+<mat-table [dataSource]="dataSource">
+    <ng-container matColumnDef="name">
+        <mat-header-cell data-automation-id="table-header-cell-name" *matHeaderCellDef>{{ 'SDK.VARIABLE_MAPPING.PARAMETER' | translate }}</mat-header-cell>
+        <mat-cell
+            *matCellDef="let parameter"
+            matTooltip="{{ parameter.description + ' (type: ' + parameter.type + ')' }}"
+            matTooltipPosition="before"
+            matTooltipShowDelay="1000"
+            [attr.data-automation-id]="'param-id-' + parameter.id">
+            <span>{{ parameter.name }}</span>
+        </mat-cell>
+    </ng-container>
+    <ng-container matColumnDef="process-variable">
+        <mat-header-cell data-automation-id="table-header-cell-process-variables" *matHeaderCellDef>
+            {{ 'SDK.VARIABLE_MAPPING.PROCESS_VARIABLE' | translate }}
+        </mat-header-cell>
+        <mat-cell *matCellDef="let parameter">
+            <mat-select
+                *ngIf="optionsForParams[parameter.name]?.length; else noProcessPropertiesTmpl"
+                placeholder="{{ 'SDK.VARIABLE_MAPPING.PROCESS_VARIABLE' | translate }}"
+                (selectionChange)="changeSelection($event, parameter)"
+                [value]="paramName2VariableName[parameter.name]"
+                matTooltipPosition="before"
+                [attr.data-automation-id]="'variable-selector-' + parameter.id">
+                <mat-option *ngFor="let property of optionsForParams[parameter.name]" [value]="property.name">
+                    {{ property.name }}
+                </mat-option>
+            </mat-select>
+            <mat-icon
+                [attr.data-automation-id]="'clear-icon-' + parameter.id"
+                matTooltip="{{ 'SDK.VARIABLE_MAPPING.CLEAR_ASSIGNMENT' | translate }}"
+                matTooltipPosition="before"
+                matTooltipShowDelay="1000"
+                (click)="clearSelection(parameter.name)"
+                class="amasdk-input-mapping-table__mapping-icon">clear
+            </mat-icon>
+        </mat-cell>
+    </ng-container>
+    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+    <mat-row *matRowDef="let row; columns: displayedColumns; let i = index;"></mat-row>
+</mat-table>
+
+<ng-template #noProcessPropertiesTmpl>
+    <span class="no-process-properties-msg">{{ 'SDK.VARIABLE_MAPPING.NO_PROCESS_PROPERTIES' | translate }}</span>
+</ng-template>

--- a/projects/ama-sdk/src/lib/components/output-mapping-table/output-mapping-table.component.scss
+++ b/projects/ama-sdk/src/lib/components/output-mapping-table/output-mapping-table.component.scss
@@ -1,0 +1,52 @@
+@mixin amasdk-output-mapping-table($theme) {
+    $foreground: map-get($theme, foreground);
+    $error: map-get($theme, warn);
+
+    .amasdk-output-mapping-table {
+        .mat-table {
+            border: 1px solid mat-color($foreground, text, 0.07);
+        }
+
+        .mat-header-cell:first-of-type {
+            padding-left: 0;
+        }
+
+        .mat-header-cell:last-of-type {
+            padding-right: 0;
+        }
+
+        .required-parameter {
+            color: mat-color($error);
+        }
+
+        .mat-cell {
+            margin: 0;
+            padding: 0;
+            display: block;
+            min-height: initial;
+            display: flex;
+            justify-content: space-between;
+        }
+
+        .mat-header-cell {
+            padding-left: 0;
+            padding-right: 0;
+            margin-left: 0;
+        }
+
+        &__mapped-value {
+            border: 1px solid mat-color($foreground, text, 0.07);
+            margin-top: 0;
+        }
+
+        &__mapping-icon.mat-icon {
+            vertical-align: middle;
+            margin-left: 5px;
+            width: 20px;
+            height: 20px;
+            &:hover {
+                cursor: pointer;
+            }
+        }
+    }
+}

--- a/projects/ama-sdk/src/lib/components/output-mapping-table/output-mapping-table.component.spec.ts
+++ b/projects/ama-sdk/src/lib/components/output-mapping-table/output-mapping-table.component.spec.ts
@@ -1,0 +1,176 @@
+ /*!
+ * @license
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatTableModule, MatTooltipModule, MatSelectModule, MatFormFieldModule } from '@angular/material';
+import { TranslateModule } from '@ngx-translate/core';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { FormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { MappingType } from '../../api/types';
+import { OutputMappingTableComponent } from './output-mapping-table.component';
+
+describe('OutputMappingTableComponent', () => {
+    let fixture: ComponentFixture<OutputMappingTableComponent>;
+    let component: OutputMappingTableComponent;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                MatTableModule,
+                TranslateModule.forRoot(),
+                MatTooltipModule,
+                MatSelectModule,
+                MatFormFieldModule,
+                NoopAnimationsModule,
+                FormsModule
+            ],
+            declarations: [
+                OutputMappingTableComponent
+            ],
+            providers: [],
+            schemas: [NO_ERRORS_SCHEMA]
+        });
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(OutputMappingTableComponent);
+        component = fixture.componentInstance;
+        component.parameters = [{
+            id: 'id1',
+            name: 'name',
+            description: 'desc',
+            type: 'string'
+        }];
+        component.processProperties = [
+            {
+                id: '1',
+                name: 'var1',
+                type: 'string',
+                required: false,
+                value: ''
+            },
+            {
+                id: '2',
+                name: 'var2',
+                type: 'date',
+                required: false,
+                value: ''
+            },
+            {
+                id: 'stringVarId',
+                name: 'stringVar',
+                type: 'string',
+                required: false,
+                value: ''
+            }
+        ];
+        component.mapping = {};
+
+        component.ngOnChanges();
+        fixture.detectChanges();
+    });
+
+    it('should render component', () => {
+        expect(component).not.toBeNull();
+    });
+
+    it('should emit the correct data when a property value is set', () => {
+        spyOn(component.update, 'emit');
+        const select = fixture.debugElement.query(By.css('.mat-select-trigger'));
+        select.nativeElement.click();
+        fixture.detectChanges();
+
+        const options = fixture.debugElement.queryAll(By.css('.mat-option'));
+        options[0].nativeElement.click();
+        fixture.detectChanges();
+
+        const data = { [component.processProperties[0].name]: {
+            type: MappingType.variable,
+            value: component.parameters[0].name
+        }};
+        expect(component.update.emit).toHaveBeenCalledWith(data);
+    });
+
+    it('should emit the correct data when a property value is reset', () => {
+        spyOn(component.update, 'emit');
+        component.mapping = { [component.processProperties[0].name]: {
+            type: MappingType.variable,
+            value: component.parameters[0].name
+        }};
+        component.ngOnChanges();
+
+        const select = fixture.debugElement.query(By.css('.mat-select-trigger'));
+        select.nativeElement.click();
+        fixture.detectChanges();
+        const options = fixture.debugElement.queryAll(By.css('.mat-option'));
+        options[1].nativeElement.click();
+        fixture.detectChanges();
+
+        const data = { [component.processProperties[2].name]: {
+            type: MappingType.variable,
+            value: component.parameters[0].name
+        }};
+
+        expect(component.update.emit).toHaveBeenCalledWith(data);
+    });
+
+    it('should filter the processProperties', () => {
+        const select = fixture.debugElement.query(By.css('.mat-select-trigger'));
+        select.nativeElement.click();
+        fixture.detectChanges();
+
+        const options = fixture.debugElement.queryAll(By.css('.mat-option'));
+        expect(options.length).toBe(2, 'Two options are expected from type: string');
+    });
+
+    it('should display a message if no process property', () => {
+        component.parameters[0].type = 'boolean';
+        component.ngOnChanges();
+        fixture.detectChanges();
+
+        const select = fixture.debugElement.query(By.css('.mat-select'));
+        const noPropMsg = fixture.debugElement.query(By.css('.no-process-properties-msg'));
+
+        expect(select).toBeNull();
+        expect(noPropMsg).not.toBeNull();
+    });
+
+    it('if a parameter is marked non-required then None value will appear first in the properties list to choose from', () => {
+        component.parameters.push({id: 'id2', name: 'name2', type: 'string', required: false});
+        component.ngOnChanges();
+        fixture.detectChanges();
+
+        expect(component.optionsForParams['name2'][0]).toEqual({id: null, name: 'None'});
+    });
+
+    it('if a parameter is marked required or not marked at all then None value will appear first in the properties list to choose from', () => {
+        component.parameters.push({id: 'id3', name: 'name3', type: 'string', required: true});
+        component.ngOnChanges();
+        fixture.detectChanges();
+
+        expect(component.optionsForParams['name']).toEqual([
+            component.processProperties[0],
+            component.processProperties[2]
+        ]);
+        expect(component.optionsForParams['name3']).toEqual([
+            component.processProperties[0],
+            component.processProperties[2]
+        ]);
+    });
+});

--- a/projects/ama-sdk/src/lib/components/output-mapping-table/output-mapping-table.component.ts
+++ b/projects/ama-sdk/src/lib/components/output-mapping-table/output-mapping-table.component.ts
@@ -1,0 +1,105 @@
+ /*!
+ * @license
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
+import { MatTableDataSource } from '@angular/material';
+import { ConnectorParameter, EntityProperty, MappingType, ServiceOutputParameterMapping, ServiceParameterMappings } from '../../api/types';
+
+@Component({
+    selector: 'amasdk-output-mapping-table',
+    templateUrl: 'output-mapping-table.component.html',
+    host: { class: 'amasdk-input-mapping-table' }
+})
+export class OutputMappingTableComponent implements OnChanges {
+    @Input()
+    parameters: ConnectorParameter[];
+
+    @Input()
+    processProperties: EntityProperty[];
+
+    @Input()
+    mapping: ServiceOutputParameterMapping;
+
+    @Output()
+    update = new EventEmitter<ServiceParameterMappings>();
+    data: ServiceOutputParameterMapping = {};
+
+    displayedColumns: string[] = ['name', 'process-variable'];
+    dataSource: MatTableDataSource<ConnectorParameter>;
+    optionsForParams: {
+        [paramName: string]: { id: string; name: string }[];
+    } = {};
+    paramName2VariableName: { [paramName: string]: string } = {};
+
+    ngOnChanges() {
+        this.initOptionsForParams();
+        this.initMapping();
+        this.dataSource = new MatTableDataSource(this.parameters);
+        this.data = { ...this.mapping };
+    }
+
+    changeSelection(
+        { value: variableName },
+        parameter: ConnectorParameter
+    ): void {
+        const previousVariableMapped = this.paramName2VariableName[
+            parameter.name
+        ];
+        if (previousVariableMapped) {
+            delete this.data[previousVariableMapped];
+        }
+
+        this.data[variableName] = {
+            type: MappingType.variable,
+            value: parameter.name
+        };
+        this.update.emit(this.data);
+    }
+
+    clearSelection(parameterName) {
+        delete this.data[this.paramName2VariableName[parameterName]];
+        delete this.paramName2VariableName[parameterName];
+        this.update.emit(this.data);
+    }
+
+    initOptionsForParams() {
+        this.parameters.forEach(this.setOptionForAParam.bind(this));
+    }
+
+    private setOptionForAParam(param) {
+        this.optionsForParams[param.name] = [
+            ...(param.required === false ? [{ id: null, name: 'None' }] : []),
+            ...this.processProperties
+                .filter(variable => variable.type === param.type)
+                .filter(
+                    variable =>
+                        !this.mapping[variable.name] ||
+                        this.mapping[variable.name].value === param.name
+                )
+        ];
+    }
+
+    initMapping() {
+        const variableNames = Object.keys(this.mapping);
+
+        for (const variableName of variableNames) {
+            this.paramName2VariableName[
+                this.mapping[variableName].value
+            ] = variableName;
+        }
+    }
+}

--- a/projects/ama-sdk/src/lib/components/output-mapping-table/output-mapping-table.module.ts
+++ b/projects/ama-sdk/src/lib/components/output-mapping-table/output-mapping-table.module.ts
@@ -1,0 +1,37 @@
+ /*!
+ * @license
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CoreModule } from '@alfresco/adf-core';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { MatIconModule, MatInputModule, MatSelectModule, MatTableModule, MatTooltipModule } from '@angular/material';
+import { OutputMappingTableComponent } from './output-mapping-table.component';
+
+@NgModule({
+    imports: [
+        CommonModule,
+        MatTableModule,
+        MatIconModule,
+        MatTooltipModule,
+        MatSelectModule,
+        MatInputModule,
+        CoreModule.forChild()
+    ],
+    declarations: [OutputMappingTableComponent],
+    exports: [OutputMappingTableComponent]
+})
+export class OutputMappingTableModule {}

--- a/projects/ama-sdk/src/lib/components/output-mapping-table/public_api.ts
+++ b/projects/ama-sdk/src/lib/components/output-mapping-table/public_api.ts
@@ -1,0 +1,19 @@
+ /*!
+ * @license
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './output-mapping-table.component';
+export * from './output-mapping-table.module';

--- a/projects/ama-sdk/src/lib/helpers/shared.module.scss
+++ b/projects/ama-sdk/src/lib/helpers/shared.module.scss
@@ -1,9 +1,11 @@
 @import "./components/header-breadcrumbs/header-breadcrumbs.component";
 @import "./components/editor-footer/editor-footer.component";
 @import "../components/input-mapping-table/input-mapping-table.component";
+@import "../components/output-mapping-table/output-mapping-table.component";
 
 @mixin amasdk-shared-module($theme) {
     @include amasdk-header-breadcrumbs($theme);
     @include amasdk-editor-footer($theme);
     @include amasdk-input-mapping-table($theme);
+    @include amasdk-output-mapping-table($theme);
 }

--- a/projects/ama-sdk/src/lib/helpers/shared.module.scss
+++ b/projects/ama-sdk/src/lib/helpers/shared.module.scss
@@ -1,7 +1,9 @@
 @import "./components/header-breadcrumbs/header-breadcrumbs.component";
 @import "./components/editor-footer/editor-footer.component";
+@import "../components/input-mapping-table/input-mapping-table.component";
 
 @mixin amasdk-shared-module($theme) {
     @include amasdk-header-breadcrumbs($theme);
     @include amasdk-editor-footer($theme);
+    @include amasdk-input-mapping-table($theme);
 }

--- a/projects/ama-sdk/src/lib/helpers/shared.module.ts
+++ b/projects/ama-sdk/src/lib/helpers/shared.module.ts
@@ -26,6 +26,7 @@ import { CoreModule } from '@alfresco/adf-core';
 import { AllowedCharactersDirective } from './directives/allowed-characters.directive';
 import { EditorFooterComponent } from './components/editor-footer/editor-footer.component';
 import { LoggingModule } from '../logging/logging.module';
+import { InputMappingTableModule } from '../components/input-mapping-table/public_api';
 
 @NgModule({
     imports: [
@@ -33,6 +34,7 @@ import { LoggingModule } from '../logging/logging.module';
         MatIconModule,
         RouterModule,
         LoggingModule,
+        InputMappingTableModule,
         CoreModule.forChild(),
     ],
     declarations: [
@@ -48,7 +50,8 @@ import { LoggingModule } from '../logging/logging.module';
         HeaderBreadcrumbsComponent,
         EntityDialogComponent,
         EditorFooterComponent,
-        AllowedCharactersDirective
+        AllowedCharactersDirective,
+        InputMappingTableModule
     ]
 })
 export class SharedModule {}

--- a/projects/ama-sdk/src/lib/helpers/shared.module.ts
+++ b/projects/ama-sdk/src/lib/helpers/shared.module.ts
@@ -26,7 +26,8 @@ import { CoreModule } from '@alfresco/adf-core';
 import { AllowedCharactersDirective } from './directives/allowed-characters.directive';
 import { EditorFooterComponent } from './components/editor-footer/editor-footer.component';
 import { LoggingModule } from '../logging/logging.module';
-import { InputMappingTableModule } from '../components/input-mapping-table/public_api';
+import { InputMappingTableModule } from '../components/input-mapping-table/input-mapping-table.module';
+import { OutputMappingTableModule } from '../components/output-mapping-table/output-mapping-table.module';
 
 @NgModule({
     imports: [
@@ -35,6 +36,7 @@ import { InputMappingTableModule } from '../components/input-mapping-table/publi
         RouterModule,
         LoggingModule,
         InputMappingTableModule,
+        OutputMappingTableModule,
         CoreModule.forChild(),
     ],
     declarations: [
@@ -51,7 +53,8 @@ import { InputMappingTableModule } from '../components/input-mapping-table/publi
         EntityDialogComponent,
         EditorFooterComponent,
         AllowedCharactersDirective,
-        InputMappingTableModule
+        InputMappingTableModule,
+        OutputMappingTableModule
     ]
 })
 export class SharedModule {}

--- a/projects/ama-sdk/src/public_api.ts
+++ b/projects/ama-sdk/src/public_api.ts
@@ -23,6 +23,7 @@
 
 export * from './lib/api/public_api';
 export * from './lib/code-editor/public_api';
+export * from './lib/components/input-mapping-table/public_api';
 export * from './lib/process-editor/public_api';
 export * from './lib/connector-editor/public_api';
 export * from './lib/confirmation-dialog/public_api';

--- a/projects/ama-sdk/src/public_api.ts
+++ b/projects/ama-sdk/src/public_api.ts
@@ -24,6 +24,7 @@
 export * from './lib/api/public_api';
 export * from './lib/code-editor/public_api';
 export * from './lib/components/input-mapping-table/public_api';
+export * from './lib/components/output-mapping-table/public_api';
 export * from './lib/process-editor/public_api';
 export * from './lib/connector-editor/public_api';
 export * from './lib/confirmation-dialog/public_api';

--- a/tslint.json
+++ b/tslint.json
@@ -125,13 +125,13 @@
         "directive-selector": [
             true,
             "attribute",
-            "ama",
+            ["ama", "amasdk"],
             "kebab-case"
         ],
         "component-selector": [
             true,
             "element",
-            "ama",
+            ["ama", "amasdk" ],
             "kebab-case"
         ],
         "use-input-property-decorator": true,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- add Input/Output variable mapping table components
- fix the layout issue with static input (APM-1117)

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
