### PR TITLE
[ADF-1163] Add user-friendly configuration interface for Timers

### DIFF
--- a/src/app/process-editor/i18n/en.json
+++ b/src/app/process-editor/i18n/en.json
@@ -57,10 +57,22 @@
             "FORM_SELECTOR": "Form selector",
             "DEFAULT_SEQUENCE_FLOW": "Default sequence flow",
             "PROCESS_NAME_REQUIRED": "Process name is required",
-            "TIMER_DEFINITION_REQUIRED": "Timer definition is required",
-            "TIMER_TYPE": "Timer type",
-            "TIMER_DEFINITION": "Timer definition",
-            "REQUIRED": "Required"
+            "TIMERS": {
+                "TIMER_TYPE": "Timer type",
+                "TIMER_DEFINITION": "Timer definition",
+                "REQUIRED": "Required",
+                "YEARS": "Years",
+                "MONTHS": "Months",
+                "WEEKS": "Weeks",
+                "DAYS": "Days",
+                "HOURS": "Hours",
+                "MINUTES": "Minutes",
+                "SECONDS": "Seconds",
+                "REPETITIONS": "Repetitions",
+                "DATE": "Date",
+                "USE_PROCESS_VARIABLE": "Use process variable",
+                "PROCESS_VARIABLE": "Process variable"
+            }
         },
         "UPLOAD_SUCCESS": "The process was successfully uploaded",
         "PROCESS_UPDATED": "The process was successfully updated",

--- a/src/app/process-editor/i18n/en.json
+++ b/src/app/process-editor/i18n/en.json
@@ -71,7 +71,10 @@
                 "REPETITIONS": "Repetitions",
                 "DATE": "Date",
                 "USE_PROCESS_VARIABLE": "Use process variable",
-                "PROCESS_VARIABLE": "Process variable"
+                "PROCESS_VARIABLE": "Process variable",
+                "USE_CRON_EXPRESSION": "Use cron expression",
+                "CRON_EXPRESSION": "Cron expression",
+                "INVALID_CRON_EXPRESSION": "Invalid cron expression"
             }
         },
         "UPLOAD_SUCCESS": "The process was successfully uploaded",

--- a/src/app/process-editor/services/cardview-properties/timer-definition-item/timer-definition-item.component.html
+++ b/src/app/process-editor/services/cardview-properties/timer-definition-item/timer-definition-item.component.html
@@ -1,29 +1,96 @@
 <div class="timer-definition-block">
     <form [formGroup]="timerDefinitionForm">
-        <div class="adf-property-label">
-            {{ 'PROCESS_EDITOR.ELEMENT_PROPERTIES.TIMER_TYPE' | translate }}
-        </div>
-        <mat-form-field>
-            <mat-select
-                [formControl]="timerType">
-                <mat-option></mat-option>
-                <mat-option *ngFor="let timer of timers" [value]="timer.key">
-                    {{ timer.label | translate }}
-                </mat-option>
-            </mat-select>
-        </mat-form-field>
-
-        <mat-form-field *ngIf="timerType.valid">
+        <div class="timer-type">
             <div class="adf-property-label">
-                {{'PROCESS_EDITOR.ELEMENT_PROPERTIES.TIMER_DEFINITION' | translate}}
+                {{ 'PROCESS_EDITOR.ELEMENT_PROPERTIES.TIMERS.TIMER_TYPE' | translate }}
             </div>
-            <input
-                matInput
-                (change)="updateTimerDefinition()"
-                [formControl]="timerDefinition"/>
-            <mat-error *ngIf="timerDefinition.hasError('required')">
-                {{ 'PROCESS_EDITOR.ELEMENT_PROPERTIES.REQUIRED' | translate }}
-            </mat-error>
-        </mat-form-field>
+            <mat-form-field>
+                <mat-select [formControl]="timerType">
+                    <mat-option></mat-option>
+                    <mat-option *ngFor="let timer of timers" [value]="timer.key">
+                        {{ timer.label | translate }}
+                    </mat-option>
+                </mat-select>
+            </mat-form-field>
+        </div>
+
+        <div *ngIf="isTimerTypeDefined()" class="timer-variable">
+            <mat-checkbox [formControl]="isProcessVariable">
+                {{'PROCESS_EDITOR.ELEMENT_PROPERTIES.TIMERS.USE_PROCESS_VARIABLE' | translate}}
+            </mat-checkbox>
+            <mat-form-field *ngIf="isProcessVariable.value">
+                <div class="adf-property-label">
+                    {{'PROCESS_EDITOR.ELEMENT_PROPERTIES.TIMERS.PROCESS_VARIABLE' | translate}}
+                </div>
+                <input matInput [formControl]="processVariable" />
+            </mat-form-field>
+        </div>
+
+        <div *ngIf="isCycleTimer()" class="timer-cycle">
+            <mat-form-field>
+                <div class="adf-property-label">
+                    {{'PROCESS_EDITOR.ELEMENT_PROPERTIES.TIMERS.REPETITIONS' | translate}}
+                </div>
+                <input matInput [formControl]="repetitions" />
+            </mat-form-field>
+        </div>
+
+        <div *ngIf="isDateTimer()" class="timer-date">
+            <mat-form-field>
+                <div class="adf-property-label">{{'PROCESS_EDITOR.ELEMENT_PROPERTIES.TIMERS.DATE' | translate}}</div>
+                <mat-datetimepicker-toggle [for]="datetimePicker" matSuffix></mat-datetimepicker-toggle>
+                <mat-datetimepicker #datetimePicker type="datetime" openOnFocus="true" timeInterval="1">
+                </mat-datetimepicker>
+                <input matInput [formControl]="date" [matDatetimepicker]="datetimePicker" [min]="today"
+                    autocomplete="false">
+            </mat-form-field>
+        </div>
+
+        <div *ngIf="isDurationTimer()" class="timer-duration">
+            <div class="timer-duration-date">
+                <mat-form-field>
+                    <div class="adf-property-label">{{'PROCESS_EDITOR.ELEMENT_PROPERTIES.TIMERS.YEARS' | translate}}
+                    </div>
+                    <input matInput [formControl]="years" />
+                </mat-form-field>
+                <mat-form-field>
+                    <div class="adf-property-label">{{'PROCESS_EDITOR.ELEMENT_PROPERTIES.TIMERS.MONTHS' | translate}}
+                    </div>
+                    <input matInput [formControl]="months" />
+                </mat-form-field>
+            </div>
+
+            <div class="timer-duration-date">
+                <mat-form-field>
+                    <div class="adf-property-label">{{'PROCESS_EDITOR.ELEMENT_PROPERTIES.TIMERS.WEEKS' | translate}}
+                    </div>
+                    <input matInput [formControl]="weeks" />
+                </mat-form-field>
+                <mat-form-field>
+                    <div class="adf-property-label">{{'PROCESS_EDITOR.ELEMENT_PROPERTIES.TIMERS.DAYS' | translate}}
+                    </div>
+                    <input matInput [formControl]="days" />
+                </mat-form-field>
+            </div>
+
+            <div class="timer-duration-time">
+                <mat-form-field>
+                    <div class="adf-property-label">{{'PROCESS_EDITOR.ELEMENT_PROPERTIES.TIMERS.HOURS' | translate}}
+                    </div>
+                    <input matInput [formControl]="hours" />
+                </mat-form-field>
+                <mat-form-field>
+                    <div class="adf-property-label">{{'PROCESS_EDITOR.ELEMENT_PROPERTIES.TIMERS.MINUTES' | translate}}
+                    </div>
+                    <input matInput [formControl]="minutes" />
+                </mat-form-field>
+                <mat-form-field>
+                    <div class="adf-property-label">{{'PROCESS_EDITOR.ELEMENT_PROPERTIES.TIMERS.SECONDS' | translate}}
+                    </div>
+                    <input matInput [formControl]="seconds" />
+                </mat-form-field>
+            </div>
+        </div>
+
     </form>
 </div>

--- a/src/app/process-editor/services/cardview-properties/timer-definition-item/timer-definition-item.component.html
+++ b/src/app/process-editor/services/cardview-properties/timer-definition-item/timer-definition-item.component.html
@@ -15,10 +15,10 @@
         </div>
 
         <div *ngIf="isTimerTypeDefined()" class="timer-variable">
-            <mat-checkbox [formControl]="isProcessVariable">
+            <mat-checkbox [formControl]="useProcessVariable">
                 {{'PROCESS_EDITOR.ELEMENT_PROPERTIES.TIMERS.USE_PROCESS_VARIABLE' | translate}}
             </mat-checkbox>
-            <mat-form-field *ngIf="isProcessVariable.value">
+            <mat-form-field *ngIf="useProcessVariable.value">
                 <div class="adf-property-label">
                     {{'PROCESS_EDITOR.ELEMENT_PROPERTIES.TIMERS.PROCESS_VARIABLE' | translate}}
                 </div>
@@ -27,7 +27,20 @@
         </div>
 
         <div *ngIf="isCycleTimer()" class="timer-cycle">
-            <mat-form-field>
+            <mat-checkbox [formControl]="useCronExpression">
+                {{'PROCESS_EDITOR.ELEMENT_PROPERTIES.TIMERS.USE_CRON_EXPRESSION' | translate}}
+            </mat-checkbox>
+            <mat-form-field *ngIf="useCronExpression.value">
+                <div class="adf-property-label">
+                    {{'PROCESS_EDITOR.ELEMENT_PROPERTIES.TIMERS.CRON_EXPRESSION' | translate}}
+                </div>
+                <input matInput [formControl]="cronExpression" />
+                <mat-error *ngIf="cronExpression.invalid">
+                    {{'PROCESS_EDITOR.ELEMENT_PROPERTIES.TIMERS.INVALID_CRON_EXPRESSION' | translate}}
+                </mat-error>
+            </mat-form-field>
+
+            <mat-form-field *ngIf="!useCronExpression.value">
                 <div class="adf-property-label">
                     {{'PROCESS_EDITOR.ELEMENT_PROPERTIES.TIMERS.REPETITIONS' | translate}}
                 </div>

--- a/src/app/process-editor/services/cardview-properties/timer-definition-item/timer-definition-item.component.scss
+++ b/src/app/process-editor/services/cardview-properties/timer-definition-item/timer-definition-item.component.scss
@@ -10,4 +10,32 @@
             margin-top: 7px;
         }
     }
+
+    .timer-duration-time {
+        display: flex;
+        justify-content: space-between;
+
+        .mat-form-field {
+            width: 31%;
+        }
+    }
+
+    .timer-duration-date {
+        display: flex;
+        justify-content: space-between;
+
+        .mat-form-field {
+            width: 48%;
+        }
+    }
+
+    .timer-date {
+        .mat-datetimepicker-toggle {
+            position: absolute;
+            left: -25px;
+            top: 7px;
+        }
+    }
 }
+
+

--- a/src/app/process-editor/services/cardview-properties/timer-definition-item/timer-definition-item.component.spec.ts
+++ b/src/app/process-editor/services/cardview-properties/timer-definition-item/timer-definition-item.component.spec.ts
@@ -1,0 +1,194 @@
+ /*!
+ * @license
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { CardViewTimerDefinitionItemComponent } from './timer-definition-item.component';
+import { CardItemTypeService, CardViewUpdateService, AppConfigService } from '@alfresco/adf-core';
+import { TranslateModule } from '@ngx-translate/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
+
+describe('CardViewTimerDefinitionItemComponent', () => {
+    let fixture: ComponentFixture<CardViewTimerDefinitionItemComponent>;
+    let component: CardViewTimerDefinitionItemComponent;
+    let cardViewUpdateService: CardViewUpdateService;
+
+    const timerOptionsMock = [
+        {
+            'key': 'timeCycle',
+            'label': 'PROCESS_EDITOR.TIMER_TYPES.CYCLE'
+        },
+        {
+            'key': 'timeDuration',
+            'label': 'PROCESS_EDITOR.TIMER_TYPES.DURATION'
+        },
+        {
+            'key': 'timeDate',
+            'label': 'PROCESS_EDITOR.TIMER_TYPES.DATE'
+        }
+    ];
+
+    const propertyMock = {
+        data: {
+            element: {
+                businessObject: {
+                    eventDefinitions: [{}]
+                }
+            }
+        }
+    };
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                CardItemTypeService,
+                CardViewUpdateService,
+                FormBuilder,
+                {
+                    provide: AppConfigService, useValue: {
+                        get: jest.fn('process-modeler.timer-types').mockReturnValue(timerOptionsMock)
+                    }
+                }
+            ],
+            declarations: [CardViewTimerDefinitionItemComponent],
+            imports: [TranslateModule.forRoot()],
+            schemas: [NO_ERRORS_SCHEMA]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(CardViewTimerDefinitionItemComponent);
+        component = fixture.componentInstance;
+        component.property = propertyMock;
+
+        cardViewUpdateService = TestBed.get(CardViewUpdateService);
+        fixture.detectChanges();
+    });
+
+    it('should not display timer inputs if type is not selected', () => {
+        const cycleInput = fixture.nativeElement.querySelector('div[class="timer-cycle"]');
+        const dateInput = fixture.nativeElement.querySelector('div[class="timer-date"]');
+        const durationInput = fixture.nativeElement.querySelector('div[class="timer-duration"]');
+        expect(cycleInput).toBeNull();
+        expect(dateInput).toBeNull();
+        expect(durationInput).toBeNull();
+    });
+
+    it('should not display timer inputs if processVariable is selected', () => {
+        component.timerType.setValue('timeCycle');
+        component.isProcessVariable.setValue(true);
+        fixture.detectChanges();
+        const cycleInput = fixture.nativeElement.querySelector('div[class="timer-cycle"]');
+        const dateInput = fixture.nativeElement.querySelector('div[class="timer-date"]');
+        const durationInput = fixture.nativeElement.querySelector('div[class="timer-duration"]');
+        expect(cycleInput).toBeNull();
+        expect(dateInput).toBeNull();
+        expect(durationInput).toBeNull();
+    });
+
+    it('should display timer cycle inputs if cycle type is selected', () => {
+        component.timerType.setValue('timeCycle');
+        fixture.detectChanges();
+        const cycleInput = fixture.nativeElement.querySelector('div[class="timer-cycle"]');
+        const dateInput = fixture.nativeElement.querySelector('div[class="timer-date"]');
+        const durationInput = fixture.nativeElement.querySelector('div[class="timer-duration"]');
+        expect(cycleInput).not.toBeNull();
+        expect(dateInput).not.toBeNull();
+        expect(durationInput).not.toBeNull();
+    });
+
+    it('should display timer date inputs if date type is selected', () => {
+        component.timerType.setValue('timeDate');
+        fixture.detectChanges();
+        const cycleInput = fixture.nativeElement.querySelector('div[class="timer-cycle"]');
+        const dateInput = fixture.nativeElement.querySelector('div[class="timer-date"]');
+        const durationInput = fixture.nativeElement.querySelector('div[class="timer-duration"]');
+        expect(cycleInput).toBeNull();
+        expect(dateInput).not.toBeNull();
+        expect(durationInput).toBeNull();
+    });
+
+    it('should display timer duration inputs if duration type is selected', () => {
+        component.timerType.setValue('timeDuration');
+        fixture.detectChanges();
+        const cycleInput = fixture.nativeElement.querySelector('div[class="timer-cycle"]');
+        const dateInput = fixture.nativeElement.querySelector('div[class="timer-date"]');
+        const durationInput = fixture.nativeElement.querySelector('div[class="timer-duration"]');
+        expect(cycleInput).toBeNull();
+        expect(dateInput).toBeNull();
+        expect(durationInput).not.toBeNull();
+    });
+
+    it('should update timer definition when the duration inputs are filled', () => {
+        spyOn(cardViewUpdateService, 'update');
+        component.timerType.setValue('timeDuration');
+        component.years.setValue(1);
+
+        component.updateTimerDefinition();
+        fixture.detectChanges();
+
+        expect(cardViewUpdateService.update).toHaveBeenCalledWith(component.property, {
+            type: 'timeDuration',
+            definition: 'P1Y'
+        });
+    });
+
+    it('should update timer definition when the date inputs are filled', () => {
+        spyOn(cardViewUpdateService, 'update');
+        component.timerType.setValue('timeDate');
+        component.date.setValue(new Date('2020-03-11'));
+
+        component.updateTimerDefinition();
+        fixture.detectChanges();
+
+        expect(cardViewUpdateService.update).toHaveBeenCalledWith(component.property, {
+            type: 'timeDate',
+            definition: '2020-03-11T00:00:00.000Z'
+        });
+    });
+
+    it('should update timer definition when the cycle inputs are filled', () => {
+        spyOn(cardViewUpdateService, 'update');
+        component.timerType.setValue('timeCycle');
+        component.date.setValue(new Date('2020-03-11'));
+        component.repetitions.setValue(3);
+        component.years.setValue(1);
+
+        component.updateTimerDefinition();
+        fixture.detectChanges();
+
+        expect(cardViewUpdateService.update).toHaveBeenCalledWith(component.property, {
+            type: 'timeCycle',
+            definition: 'R3/2020-03-11T00:00:00.000Z/P1Y'
+        });
+    });
+
+    it('should update timer definition when the process variable input is filled', () => {
+        spyOn(cardViewUpdateService, 'update');
+        component.timerType.setValue('timeCycle');
+        component.isProcessVariable.setValue(true);
+        component.processVariable.setValue('myVariable');
+
+        component.updateTimerDefinition();
+        fixture.detectChanges();
+
+        expect(cardViewUpdateService.update).toHaveBeenCalledWith(component.property, {
+            type: 'timeCycle',
+            definition: '${myVariable}'
+        });
+    });
+});

--- a/src/app/process-editor/services/cardview-properties/timer-definition-item/timer-definition-item.component.spec.ts
+++ b/src/app/process-editor/services/cardview-properties/timer-definition-item/timer-definition-item.component.spec.ts
@@ -90,7 +90,7 @@ describe('CardViewTimerDefinitionItemComponent', () => {
 
     it('should not display timer inputs if processVariable is selected', () => {
         component.timerType.setValue('timeCycle');
-        component.isProcessVariable.setValue(true);
+        component.useProcessVariable.setValue(true);
         fixture.detectChanges();
         const cycleInput = fixture.nativeElement.querySelector('div[class="timer-cycle"]');
         const dateInput = fixture.nativeElement.querySelector('div[class="timer-date"]');
@@ -177,10 +177,25 @@ describe('CardViewTimerDefinitionItemComponent', () => {
         });
     });
 
+    it('should update timer definition when the cycle input is filled with cron expression', () => {
+        spyOn(cardViewUpdateService, 'update');
+        component.timerType.setValue('timeCycle');
+        component.useCronExpression.setValue(true);
+        component.cronExpression.setValue('0 0/5 * * * ?');
+
+        component.updateTimerDefinition();
+        fixture.detectChanges();
+
+        expect(cardViewUpdateService.update).toHaveBeenCalledWith(component.property, {
+            type: 'timeCycle',
+            definition: '0 0/5 * * * ?'
+        });
+    });
+
     it('should update timer definition when the process variable input is filled', () => {
         spyOn(cardViewUpdateService, 'update');
         component.timerType.setValue('timeCycle');
-        component.isProcessVariable.setValue(true);
+        component.useProcessVariable.setValue(true);
         component.processVariable.setValue('myVariable');
 
         component.updateTimerDefinition();

--- a/src/app/process-editor/services/cardview-properties/timer-definition-item/timer-definition-item.component.ts
+++ b/src/app/process-editor/services/cardview-properties/timer-definition-item/timer-definition-item.component.ts
@@ -20,6 +20,7 @@ import { CardItemTypeService, CardViewUpdateService, AppConfigService } from '@a
 import { FormBuilder, Validators, FormControl, FormGroup, AbstractControl } from '@angular/forms';
 import { debounceTime, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
+import moment from 'moment-es6';
 
 @Component({
     selector: 'ama-process-timer-definition',
@@ -27,6 +28,9 @@ import { Subject } from 'rxjs';
     providers: [CardItemTypeService]
 })
 export class CardViewTimerDefinitionItemComponent implements OnInit, OnDestroy {
+
+    MIN_TIME_VALUE = 0;
+
     @Input() property;
 
     timers = [];
@@ -34,6 +38,7 @@ export class CardViewTimerDefinitionItemComponent implements OnInit, OnDestroy {
     defaultTimerDefinition = '';
     defaultTimerType = '';
     timerDefinitionForm: FormGroup;
+    today = new Date();
 
     onDestroy$: Subject<void> = new Subject<void>();
 
@@ -41,19 +46,29 @@ export class CardViewTimerDefinitionItemComponent implements OnInit, OnDestroy {
         private cardViewUpdateService: CardViewUpdateService,
         private appConfigService: AppConfigService,
         private formBuilder: FormBuilder
-    ) {}
+    ) { }
 
     ngOnInit() {
-        this.setTimerFromXML();
         this.timers = this.appConfigService.get('process-modeler.timer-types');
 
         this.buildForm();
+        this.setTimerFromXML();
     }
 
     buildForm() {
         this.timerDefinitionForm = this.formBuilder.group({
-            timerType: new FormControl(this.defaultTimerType, [Validators.required]),
-            timerDefinition: new FormControl(this.defaultTimerDefinition, [Validators.required])
+            timerType: new FormControl(undefined, [Validators.required]),
+            date: new FormControl(undefined, []),
+            years: new FormControl(undefined, [Validators.min(this.MIN_TIME_VALUE)]),
+            months: new FormControl(undefined, [Validators.min(this.MIN_TIME_VALUE)]),
+            weeks: new FormControl(undefined, [Validators.min(this.MIN_TIME_VALUE)]),
+            days: new FormControl(undefined, [Validators.min(this.MIN_TIME_VALUE)]),
+            hours: new FormControl(undefined, [Validators.min(this.MIN_TIME_VALUE)]),
+            minutes: new FormControl(undefined, [Validators.min(this.MIN_TIME_VALUE)]),
+            seconds: new FormControl(undefined, [Validators.min(this.MIN_TIME_VALUE)]),
+            repetitions: new FormControl(undefined, [Validators.min(this.MIN_TIME_VALUE)]),
+            processVariable: new FormControl(undefined, []),
+            isProcessVariable: new FormControl(false, []),
         });
 
         this.timerDefinitionForm.valueChanges
@@ -61,47 +76,178 @@ export class CardViewTimerDefinitionItemComponent implements OnInit, OnDestroy {
                 debounceTime(500),
                 takeUntil(this.onDestroy$)
             )
-            .subscribe((timerDefinitionValues: any) => {
+            .subscribe(() => {
                 if (this.isFormValid()) {
-                    this.updateTimerDefinition(timerDefinitionValues);
+                    this.updateTimerDefinition();
                 }
             });
     }
 
-    updateTimerDefinition(timerDefinitionValues: any) {
-        if (timerDefinitionValues) {
+    updateTimerDefinition() {
+        const timerDefinition = this.getTimerDefinitionFromForm();
+
             this.cardViewUpdateService.update(this.property, {
-                type: timerDefinitionValues.timerType,
-                definition: timerDefinitionValues.timerDefinition
+                type: this.timerType.value,
+                definition: timerDefinition
             });
+    }
+
+    getTimerDefinitionFromForm(): string {
+        let definition = '';
+
+        if (this.isProcessVariable.value) {
+            return '${' + this.processVariable.value + '}';
         }
+
+        if (this.isCycleTimer()) {
+            definition += 'R';
+            definition += this.repetitions.value ? this.repetitions.value : '';
+            definition += '/';
+        }
+
+        if (this.isDateTimer()) {
+            definition += this.date.value ? this.date.value.toISOString() : '';
+            definition += this.isCycleTimer() && this.date.value ? '/' : '';
+        }
+
+        if (this.isDurationTimer()) {
+            definition += moment.duration({
+                seconds: this.seconds.value,
+                minutes: this.minutes.value,
+                hours: this.hours.value,
+                days: this.days.value,
+                weeks: this.weeks.value,
+                months: this.months.value,
+                years: this.years.value
+            }).toISOString();
+        }
+
+        return definition;
     }
 
     setTimerFromXML() {
         const timerEventDefinition = this.property.data.element.businessObject.eventDefinitions[0];
 
         if (timerEventDefinition.timeCycle) {
-            this.defaultTimerType = 'timeCycle';
-            this.defaultTimerDefinition = timerEventDefinition.timeCycle.body;
+            this.timerType.setValue('timeCycle');
+            this.extractCycleFromXML(timerEventDefinition.timeCycle.body);
         } else if (timerEventDefinition.timeDuration) {
-            this.defaultTimerType = 'timeDuration';
-            this.defaultTimerDefinition = timerEventDefinition.timeDuration.body;
+            this.timerType.setValue('timeDuration');
+            this.extractDurationFromXML(timerEventDefinition.timeDuration.body);
         } else if (timerEventDefinition.timeDate) {
-            this.defaultTimerType = 'timeDate';
-            this.defaultTimerDefinition = timerEventDefinition.timeDate.body;
+            this.timerType.setValue('timeDate');
+            this.extractDateFromXML(timerEventDefinition.timeDate.body);
         }
+    }
+
+    extractCycleFromXML(cycleDefinitionValue: string) {
+        if (cycleDefinitionValue.includes('$')) {
+            this.extractProcessVariableFromXML(cycleDefinitionValue);
+        } else {
+            const timerDefinitions = cycleDefinitionValue.split('/');
+            this.repetitions.setValue(timerDefinitions[0].substring(1));
+
+            this.extractDateFromXML(timerDefinitions[1]);
+            this.extractDurationFromXML(timerDefinitions[2]);
+        }
+    }
+
+    extractDateFromXML(dateDefinitionValue: string) {
+        if (dateDefinitionValue.includes('$')) {
+            this.extractProcessVariableFromXML(dateDefinitionValue);
+        } else {
+            this.date.setValue(new Date(dateDefinitionValue));
+        }
+    }
+
+    extractDurationFromXML(durationDefinition: string) {
+        if (durationDefinition.includes('$')) {
+            this.extractProcessVariableFromXML(durationDefinition);
+        } else {
+            const parsedDuration = <any>moment.duration(durationDefinition);
+
+            this.years.setValue(parsedDuration._data.years);
+            this.months.setValue(parsedDuration._data.months);
+            this.weeks.setValue(Math.floor(parsedDuration._data.days / 7));
+            this.days.setValue(parsedDuration._data.days % 7);
+            this.hours.setValue(parsedDuration._data.hours);
+            this.minutes.setValue(parsedDuration._data.minutes);
+            this.seconds.setValue(parsedDuration._data.seconds);
+        }
+    }
+
+    extractProcessVariableFromXML(processVariableDefinition: string) {
+        const processVariable = processVariableDefinition.substr(2, processVariableDefinition.length - 3);
+        this.processVariable.setValue(processVariable);
+        this.isProcessVariable.setValue(true);
     }
 
     isFormValid() {
         return this.timerDefinitionForm && this.timerDefinitionForm.dirty && this.timerDefinitionForm.valid;
     }
 
+    isDateTimer() {
+        return (this.timerType.value === 'timeDate' || this.isCycleTimer()) && !this.isProcessVariable.value;
+    }
+
+    isDurationTimer() {
+        return (this.timerType.value === 'timeDuration' || this.isCycleTimer()) && !this.isProcessVariable.value;
+    }
+
+    isCycleTimer() {
+        return this.timerType.value === 'timeCycle' && !this.isProcessVariable.value;
+    }
+
+    isTimerTypeDefined() {
+        return !!this.timerType.value;
+    }
+
     get timerType(): AbstractControl {
         return this.timerDefinitionForm.get('timerType');
     }
 
-    get timerDefinition(): AbstractControl {
-        return this.timerDefinitionForm.get('timerDefinition');
+    get date(): AbstractControl {
+        return this.timerDefinitionForm.get('date');
+    }
+
+    get years(): AbstractControl {
+        return this.timerDefinitionForm.get('years');
+    }
+
+    get months(): AbstractControl {
+        return this.timerDefinitionForm.get('months');
+    }
+
+    get weeks(): AbstractControl {
+        return this.timerDefinitionForm.get('weeks');
+    }
+
+    get days(): AbstractControl {
+        return this.timerDefinitionForm.get('days');
+    }
+
+    get hours(): AbstractControl {
+        return this.timerDefinitionForm.get('hours');
+    }
+
+    get minutes(): AbstractControl {
+        return this.timerDefinitionForm.get('minutes');
+    }
+
+    get seconds(): AbstractControl {
+        return this.timerDefinitionForm.get('seconds');
+    }
+
+    get repetitions(): AbstractControl {
+        return this.timerDefinitionForm.get('repetitions');
+    }
+
+    get processVariable(): AbstractControl {
+        return this.timerDefinitionForm.get('processVariable');
+    }
+
+    get isProcessVariable(): AbstractControl {
+        return this.timerDefinitionForm.get('isProcessVariable');
     }
 
     ngOnDestroy() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/APM-1163


**What is the new behaviour?**
It was kind of difficult to set a correct timer definition following the ISO 8601. In order to make this process simpler for the end user the timers have now a menu where the definitions can be configured.
<img width="367" alt="Screen Shot 2019-07-16 at 14 17 11" src="https://user-images.githubusercontent.com/18293044/61297931-3163af80-a7d5-11e9-8f60-851cb07e058b.png">
It's a dynamic menu. Depending on the timer type selected different inputs are displayed.
The possibility of adding process variables to timers has been added as well.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/APM-1163