### PR TITLE
[APM-1200] Check that definition from XML is not undefined

### DIFF
--- a/src/app/process-editor/services/cardview-properties/timer-definition-item/timer-definition-item.component.ts
+++ b/src/app/process-editor/services/cardview-properties/timer-definition-item/timer-definition-item.component.ts
@@ -156,17 +156,23 @@ export class CardViewTimerDefinitionItemComponent implements OnInit, OnDestroy {
     }
 
     extractCycleFromXML(cycleDefinitionValue: string) {
-        if (cycleDefinitionValue.includes('$')) {
-            this.extractProcessVariableFromXML(cycleDefinitionValue);
-        } else if (this.isCronExpression(cycleDefinitionValue)) {
-            this.cronExpression.setValue(cycleDefinitionValue);
-            this.useCronExpression.setValue(true);
-        } else {
-            const timerDefinitions = cycleDefinitionValue.split('/');
-            this.repetitions.setValue(timerDefinitions[0].substring(1));
+        if (cycleDefinitionValue) {
+            if (cycleDefinitionValue.includes('$')) {
+                this.extractProcessVariableFromXML(cycleDefinitionValue);
+            } else if (this.isCronExpression(cycleDefinitionValue)) {
+                this.cronExpression.setValue(cycleDefinitionValue);
+                this.useCronExpression.setValue(true);
+            } else {
+                const timerDefinitions = cycleDefinitionValue.split('/');
+                this.repetitions.setValue(timerDefinitions[0].substring(1));
 
-            this.extractDateFromXML(timerDefinitions[1]);
-            this.extractDurationFromXML(timerDefinitions[2]);
+                if (timerDefinitions.length === 2) {
+                    this.extractDurationFromXML(timerDefinitions[1]);
+                } else {
+                    this.extractDateFromXML(timerDefinitions[1]);
+                    this.extractDurationFromXML(timerDefinitions[2]);
+                }
+            }
         }
     }
 
@@ -176,26 +182,30 @@ export class CardViewTimerDefinitionItemComponent implements OnInit, OnDestroy {
     }
 
     extractDateFromXML(dateDefinitionValue: string) {
-        if (dateDefinitionValue.includes('$')) {
-            this.extractProcessVariableFromXML(dateDefinitionValue);
-        } else {
-            this.date.setValue(new Date(dateDefinitionValue));
+        if (dateDefinitionValue) {
+            if (dateDefinitionValue.includes('$')) {
+                this.extractProcessVariableFromXML(dateDefinitionValue);
+            } else {
+                this.date.setValue(new Date(dateDefinitionValue));
+            }
         }
     }
 
     extractDurationFromXML(durationDefinition: string) {
-        if (durationDefinition.includes('$')) {
-            this.extractProcessVariableFromXML(durationDefinition);
-        } else {
-            const parsedDuration = <any>moment.duration(durationDefinition);
+        if (durationDefinition) {
+            if (durationDefinition.includes('$')) {
+                this.extractProcessVariableFromXML(durationDefinition);
+            } else {
+                const parsedDuration = <any>moment.duration(durationDefinition);
 
-            this.years.setValue(parsedDuration._data.years);
-            this.months.setValue(parsedDuration._data.months);
-            this.weeks.setValue(Math.floor(parsedDuration._data.days / 7));
-            this.days.setValue(parsedDuration._data.days % 7);
-            this.hours.setValue(parsedDuration._data.hours);
-            this.minutes.setValue(parsedDuration._data.minutes);
-            this.seconds.setValue(parsedDuration._data.seconds);
+                this.years.setValue(parsedDuration._data.years);
+                this.months.setValue(parsedDuration._data.months);
+                this.weeks.setValue(Math.floor(parsedDuration._data.days / 7));
+                this.days.setValue(parsedDuration._data.days % 7);
+                this.hours.setValue(parsedDuration._data.hours);
+                this.minutes.setValue(parsedDuration._data.minutes);
+                this.seconds.setValue(parsedDuration._data.seconds);
+            }
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/APM-1200


**What is the new behaviour?**
When the XML is edited by hand or the timer definition is empty the component could not parse the undefined value. Now we check if that value is defined

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/APM-1200